### PR TITLE
1.7.3

### DIFF
--- a/erupt-core/src/main/java/xyz/erupt/core/config/EruptProp.java
+++ b/erupt-core/src/main/java/xyz/erupt/core/config/EruptProp.java
@@ -14,7 +14,7 @@ import java.util.List;
 @Getter
 @Setter
 @Component
-@ConfigurationProperties(prefix = "erupt")
+@ConfigurationProperties("erupt")
 public class EruptProp {
 
     //热构建erupt,开启此功能后每次请求都会重新构建erupt，该功能方便启动时修改erupt代码
@@ -39,6 +39,4 @@ public class EruptProp {
     private String[] gsonHttpMessageConvertersPackages;
 
     private List<EruptPropDb> dbs;
-
-
 }

--- a/erupt-core/src/main/java/xyz/erupt/core/config/EruptPropDb.java
+++ b/erupt-core/src/main/java/xyz/erupt/core/config/EruptPropDb.java
@@ -13,8 +13,12 @@ import org.springframework.boot.autoconfigure.orm.jpa.JpaProperties;
 @Setter
 public class EruptPropDb {
 
+    private String name;
+
     private DataSourceProperties datasource;
 
     private JpaProperties jpa;
+
+    private String[] scanPackages;
 
 }

--- a/erupt-data/erupt-jpa/pom.xml
+++ b/erupt-data/erupt-jpa/pom.xml
@@ -24,5 +24,9 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/erupt-data/erupt-jpa/src/main/java/xyz/erupt/jpa/config/EruptJpaProp.java
+++ b/erupt-data/erupt-jpa/src/main/java/xyz/erupt/jpa/config/EruptJpaProp.java
@@ -1,0 +1,24 @@
+//package xyz.erupt.jpa.config;
+//
+//import lombok.Getter;
+//import lombok.Setter;
+//import org.springframework.boot.context.properties.ConfigurationProperties;
+//import org.springframework.stereotype.Component;
+//import xyz.erupt.core.config.EruptPropDb;
+//
+//import java.util.List;
+//
+///**
+// * @author YuePeng
+// * date 2021/7/13 21:04
+// */
+//@Getter
+//@Setter
+//@Component
+//@ConfigurationProperties("erupt.dbs")
+//public class EruptJpaProp {
+//
+//    private List<EruptPropDb> value;
+//
+//
+//}

--- a/erupt-job/src/main/java/xyz/erupt/job/model/EruptJobLog.java
+++ b/erupt-job/src/main/java/xyz/erupt/job/model/EruptJobLog.java
@@ -61,8 +61,7 @@ public class EruptJobLog extends BaseModel {
     )
     private Date endTime;
 
-    @Lob
-    @Type(type = "org.hibernate.type.TextType")
+    @Column(length = 2000)
     @EruptField(
             views = @View(title = "执行结果"),
             edit = @Edit(title = "执行结果")

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,6 @@
         <spring.boot.version>2.4.5</spring.boot.version>
     </properties>
 
-
     <!--
     在编译spring boot 等多模块项目的时候，往往出现
     Non-resolvable parent POM: Could not find artifact


### PR DESCRIPTION
🧩 关闭一对多弹出层点击框外就自动关闭能力
🧩 优化 erupt-monitor 手机端布局
🧩 优化 tab_table 组件滑动条出现的最大宽度
🧩 限制 table 表格最大宽度
🧩 优化审计数据的用户关联对象，EruptUser对象替换为数据结构更简单的EruptUserVo对象
🧩 magic-api升级至1.3.3
🌟 view注解附件与图片支持全路径网络资源的展示
🌟 多数据源支持自动建表，支持jpa额外配置项
🌟 @RowOperation 注解新增后置JS表达式执行，实现OperationHandler接口，afterJS方法即可