### PR TITLE
jpa查询不使用别名，以及作为前端st的cojumn索引可以不用将其中表路径的“.”与“_”进行转换

### DIFF
--- a/erupt-data/erupt-jpa/src/main/java/xyz/erupt/jpa/dao/EruptJpaDao.java
+++ b/erupt-data/erupt-jpa/src/main/java/xyz/erupt/jpa/dao/EruptJpaDao.java
@@ -1,6 +1,14 @@
 package xyz.erupt.jpa.dao;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.Resource;
+import javax.persistence.Query;
+
 import org.springframework.stereotype.Repository;
+
 import xyz.erupt.annotation.query.Condition;
 import xyz.erupt.core.annotation.EruptDataSource;
 import xyz.erupt.core.query.EruptQuery;
@@ -10,15 +18,8 @@ import xyz.erupt.core.view.EruptModel;
 import xyz.erupt.core.view.Page;
 import xyz.erupt.jpa.service.EntityManagerService;
 
-import javax.annotation.Resource;
-import javax.persistence.Query;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
 /**
- * @author YuePeng
- * date 2018-10-11.
+ * @author YuePeng date 2018-10-11.
  */
 @Repository
 public class EruptJpaDao {
@@ -53,7 +54,7 @@ public class EruptJpaDao {
     }
 
     public Page queryEruptList(EruptModel eruptModel, Page page, EruptQuery eruptQuery) {
-        String hql = EruptJpaUtils.generateEruptJpaHql(eruptModel, "new map(" + String.join(",", EruptJpaUtils.getEruptColJpaKeys(eruptModel)) + ")", eruptQuery, false);
+        String hql = EruptJpaUtils.generateEruptJpaHql(eruptModel, eruptModel.getEruptName(), eruptQuery, false);
         String countHql = EruptJpaUtils.generateEruptJpaHql(eruptModel, "count(*)", eruptQuery, true);
         return entityManagerService.getEntityManager(eruptModel.getClazz(), entityManager -> {
             Query query = entityManager.createQuery(hql);
@@ -63,36 +64,42 @@ public class EruptJpaDao {
                 for (Condition condition : eruptQuery.getConditions()) {
                     EruptFieldModel eruptFieldModel = eruptFieldMap.get(condition.getKey());
                     switch (condition.getExpression()) {
-                        case EQ:
-                            countQuery.setParameter(condition.getKey(), EruptUtil.convertObjectType(eruptFieldModel, condition.getValue()));
-                            query.setParameter(condition.getKey(), EruptUtil.convertObjectType(eruptFieldModel, condition.getValue()));
-                            break;
-                        case LIKE:
-                            countQuery.setParameter(condition.getKey(), EruptJpaUtils.PERCENT + condition.getValue() + EruptJpaUtils.PERCENT);
-                            query.setParameter(condition.getKey(), EruptJpaUtils.PERCENT + condition.getValue() + EruptJpaUtils.PERCENT);
-                            break;
-                        case RANGE:
-                            List<?> list = (List<?>) condition.getValue();
-                            countQuery.setParameter(EruptJpaUtils.L_VAL_KEY + condition.getKey(), EruptUtil.convertObjectType(eruptFieldModel, list.get(0)));
-                            countQuery.setParameter(EruptJpaUtils.R_VAL_KEY + condition.getKey(), EruptUtil.convertObjectType(eruptFieldModel, list.get(1)));
-                            query.setParameter(EruptJpaUtils.L_VAL_KEY + condition.getKey(), EruptUtil.convertObjectType(eruptFieldModel, list.get(0)));
-                            query.setParameter(EruptJpaUtils.R_VAL_KEY + condition.getKey(), EruptUtil.convertObjectType(eruptFieldModel, list.get(1)));
-                            break;
-                        case IN:
-                            List<Object> listIn = new ArrayList<>();
-                            for (Object o : (List<?>) condition.getValue()) {
-                                listIn.add(EruptUtil.convertObjectType(eruptFieldModel, o));
-                            }
-                            countQuery.setParameter(condition.getKey(), listIn);
-                            query.setParameter(condition.getKey(), listIn);
-                            break;
+                    case EQ:
+                        countQuery.setParameter(condition.getKey(), EruptUtil.convertObjectType(eruptFieldModel, condition.getValue()));
+                        query.setParameter(condition.getKey(), EruptUtil.convertObjectType(eruptFieldModel, condition.getValue()));
+                        break;
+                    case LIKE:
+                        countQuery.setParameter(condition.getKey(), EruptJpaUtils.PERCENT + condition.getValue() + EruptJpaUtils.PERCENT);
+                        query.setParameter(condition.getKey(), EruptJpaUtils.PERCENT + condition.getValue() + EruptJpaUtils.PERCENT);
+                        break;
+                    case RANGE:
+                        List<?> list = (List<?>) condition.getValue();
+                        countQuery.setParameter(EruptJpaUtils.L_VAL_KEY + condition.getKey(), EruptUtil.convertObjectType(eruptFieldModel, list.get(0)));
+                        countQuery.setParameter(EruptJpaUtils.R_VAL_KEY + condition.getKey(), EruptUtil.convertObjectType(eruptFieldModel, list.get(1)));
+                        query.setParameter(EruptJpaUtils.L_VAL_KEY + condition.getKey(), EruptUtil.convertObjectType(eruptFieldModel, list.get(0)));
+                        query.setParameter(EruptJpaUtils.R_VAL_KEY + condition.getKey(), EruptUtil.convertObjectType(eruptFieldModel, list.get(1)));
+                        break;
+                    case IN:
+                        List<Object> listIn = new ArrayList<>();
+                        for (Object o : (List<?>) condition.getValue()) {
+                            listIn.add(EruptUtil.convertObjectType(eruptFieldModel, o));
+                        }
+                        countQuery.setParameter(condition.getKey(), listIn);
+                        query.setParameter(condition.getKey(), listIn);
+                        break;
                     }
                 }
             }
             page.setTotal((Long) countQuery.getSingleResult());
             if (page.getTotal() > 0) {
-                page.setList(query.setMaxResults(page.getPageSize())
-                        .setFirstResult((page.getPageIndex() - 1) * page.getPageSize()).getResultList());
+                List<Object> objects = query.setMaxResults(page.getPageSize())
+                        .setFirstResult((page.getPageIndex() - 1) * page.getPageSize()).getResultList();
+                List<Map<String, Object>> results = new ArrayList<Map<String, Object>>();
+                for (Object obj : objects) {
+                    results.add(EruptUtil.generateEruptDataMap(eruptModel, obj));
+                }
+
+                page.setList(results);
             } else {
                 page.setList(new ArrayList<>(0));
             }


### PR DESCRIPTION
1. [test] jpa查询不使用别名，以及作为前端st的cojumn索引可以不用将其中表路径的“.”与“_”进行转换