### PR TITLE
修复权限值修改而导致没有权限

### DIFF
--- a/erupt-upms/src/main/java/xyz/erupt/upms/service/EruptMenuService.java
+++ b/erupt-upms/src/main/java/xyz/erupt/upms/service/EruptMenuService.java
@@ -103,6 +103,19 @@ public class EruptMenuService implements DataProxy<EruptMenu> {
                 Integer counter = eruptDao.getJdbcTemplate().queryForObject(
                         String.format("select count(*) from e_upms_menu where parent_menu_id = %d", eruptMenu.getId()), Integer.class
                 );
+
+                // 查询有权限菜单
+                if (null != counter && counter > 0) {
+                    Integer realCounter = eruptDao.getJdbcTemplate().queryForObject(
+                            String.format("select count(*) from e_upms_menu where parent_menu_id = %d and value like '%s@%%'", eruptMenu.getId(), eruptMenu.getValue()), Integer.class
+                    );
+                    // 如果没有查询出权限菜单，那么本次修改过Value
+                    if (null != realCounter && realCounter == 0) {
+                        eruptDao.getJdbcTemplate().update("delete from e_upms_menu where parent_menu_id = ?", new Object[] {eruptMenu.getId()});
+                        counter = 0;
+                    }
+                }
+
                 if (null != counter && counter <= 0) {
                     EruptModel eruptModel = EruptCoreService.getErupt(eruptMenu.getValue());
                     for (EruptFunPermissions value : EruptFunPermissions.values()) {


### PR DESCRIPTION
1. [bug修复] 权限值修改后，导致该菜单没有任何权限