### PR TITLE
upgrade to 1.10.12

### DIFF
--- a/erupt-annotation/pom.xml
+++ b/erupt-annotation/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>xyz.erupt</groupId>
         <artifactId>erupt</artifactId>
-        <version>1.10.11</version>
+        <version>1.10.12</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/erupt-annotation/src/main/java/xyz/erupt/annotation/fun/AutoCompleteHandler.java
+++ b/erupt-annotation/src/main/java/xyz/erupt/annotation/fun/AutoCompleteHandler.java
@@ -11,7 +11,7 @@ import java.util.Map;
  */
 public interface AutoCompleteHandler {
 
-    List<Object> completeHandler(@Comment("前端整个表单对象") Map<String,Object> formData,
+    List<Object> completeHandler(@Comment("前端其他表单组件的值") Map<String,Object> formData,
                                  @Comment("前端输入值") String val,
                                  @Comment("注解回传参数") String[] param);
 

--- a/erupt-cloud/erupt-cloud-common/pom.xml
+++ b/erupt-cloud/erupt-cloud-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>xyz.erupt</groupId>
         <artifactId>erupt</artifactId>
-        <version>1.10.11</version>
+        <version>1.10.12</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/erupt-cloud/erupt-cloud-node/pom.xml
+++ b/erupt-cloud/erupt-cloud-node/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>xyz.erupt</groupId>
         <artifactId>erupt</artifactId>
-        <version>1.10.11</version>
+        <version>1.10.12</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/erupt-cloud/erupt-cloud-server/pom.xml
+++ b/erupt-cloud/erupt-cloud-server/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>xyz.erupt</groupId>
         <artifactId>erupt</artifactId>
-        <version>1.10.11</version>
+        <version>1.10.12</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/erupt-core/pom.xml
+++ b/erupt-core/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>xyz.erupt</groupId>
         <artifactId>erupt</artifactId>
-        <version>1.10.11</version>
+        <version>1.10.12</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/erupt-data/erupt-elasticsearch/pom.xml
+++ b/erupt-data/erupt-elasticsearch/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>xyz.erupt</groupId>
         <artifactId>erupt</artifactId>
-        <version>1.10.11</version>
+        <version>1.10.12</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/erupt-data/erupt-jpa/pom.xml
+++ b/erupt-data/erupt-jpa/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>xyz.erupt</groupId>
         <artifactId>erupt</artifactId>
-        <version>1.10.11</version>
+        <version>1.10.12</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/erupt-data/erupt-mongodb/pom.xml
+++ b/erupt-data/erupt-mongodb/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>xyz.erupt</groupId>
         <artifactId>erupt</artifactId>
-        <version>1.10.11</version>
+        <version>1.10.12</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/erupt-extra/erupt-generator/pom.xml
+++ b/erupt-extra/erupt-generator/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>xyz.erupt</groupId>
         <artifactId>erupt</artifactId>
-        <version>1.10.11</version>
+        <version>1.10.12</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/erupt-extra/erupt-job/pom.xml
+++ b/erupt-extra/erupt-job/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>xyz.erupt</groupId>
         <artifactId>erupt</artifactId>
-        <version>1.10.11</version>
+        <version>1.10.12</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/erupt-extra/erupt-magic-api/pom.xml
+++ b/erupt-extra/erupt-magic-api/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>xyz.erupt</groupId>
         <artifactId>erupt</artifactId>
-        <version>1.10.11</version>
+        <version>1.10.12</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/erupt-extra/erupt-monitor/pom.xml
+++ b/erupt-extra/erupt-monitor/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>xyz.erupt</groupId>
         <artifactId>erupt</artifactId>
-        <version>1.10.11</version>
+        <version>1.10.12</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/erupt-i18n/pom.xml
+++ b/erupt-i18n/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>xyz.erupt</groupId>
         <artifactId>erupt</artifactId>
-        <version>1.10.11</version>
+        <version>1.10.12</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/erupt-security/pom.xml
+++ b/erupt-security/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>xyz.erupt</groupId>
         <artifactId>erupt</artifactId>
-        <version>1.10.11</version>
+        <version>1.10.12</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/erupt-toolkit/pom.xml
+++ b/erupt-toolkit/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>xyz.erupt</groupId>
         <artifactId>erupt</artifactId>
-        <version>1.10.11</version>
+        <version>1.10.12</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/erupt-tpl-ui/amis/pom.xml
+++ b/erupt-tpl-ui/amis/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>xyz.erupt</groupId>
         <artifactId>erupt</artifactId>
-        <version>1.10.11</version>
+        <version>1.10.12</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 </project>

--- a/erupt-tpl-ui/ant-design/pom.xml
+++ b/erupt-tpl-ui/ant-design/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>xyz.erupt</groupId>
         <artifactId>erupt</artifactId>
-        <version>1.10.11</version>
+        <version>1.10.12</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 </project>

--- a/erupt-tpl-ui/element-plus/pom.xml
+++ b/erupt-tpl-ui/element-plus/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>xyz.erupt</groupId>
         <artifactId>erupt</artifactId>
-        <version>1.10.11</version>
+        <version>1.10.12</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 </project>

--- a/erupt-tpl-ui/element-ui/pom.xml
+++ b/erupt-tpl-ui/element-ui/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>xyz.erupt</groupId>
         <artifactId>erupt</artifactId>
-        <version>1.10.11</version>
+        <version>1.10.12</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 </project>

--- a/erupt-tpl/pom.xml
+++ b/erupt-tpl/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>xyz.erupt</groupId>
         <artifactId>erupt</artifactId>
-        <version>1.10.11</version>
+        <version>1.10.12</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/erupt-upms/pom.xml
+++ b/erupt-upms/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>xyz.erupt</groupId>
         <artifactId>erupt</artifactId>
-        <version>1.10.11</version>
+        <version>1.10.12</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/erupt-web/pom.xml
+++ b/erupt-web/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>xyz.erupt</groupId>
         <artifactId>erupt</artifactId>
-        <version>1.10.11</version>
+        <version>1.10.12</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>xyz.erupt</groupId>
     <artifactId>erupt</artifactId>
-    <version>1.10.11</version>
+    <version>1.10.12</version>
 
     <packaging>pom</packaging>
     <name>erupt</name>


### PR DESCRIPTION
🐞 修复链接类型菜单在某些情况下无法让左侧菜单自动选中的BUG
🐞 修复数值区间查询0值查询不生效的BUG
🧩 调整upms相关表code列默认长度为64
🌟 升级poi依赖到最新版本，升级gson依赖到最新版本
🌟 dataproxy 新增searchCondition方法，支持过滤组件自定义查询条件配置
🌟 AutoComplete组件支持数据联动，可获取其他表单对象的值，应对更多业务场景
🌟 erupt类初始化与增加字段时会根据EruptField注解配置自动生成数据库表注释