### PR TITLE
类型转换添加枚举类型支持

### DIFF
--- a/erupt-core/src/main/java/xyz/erupt/core/util/TypeUtil.java
+++ b/erupt-core/src/main/java/xyz/erupt/core/util/TypeUtil.java
@@ -1,5 +1,6 @@
 package xyz.erupt.core.util;
 
+import lombok.SneakyThrows;
 import org.apache.commons.lang3.math.NumberUtils;
 
 import java.util.Arrays;
@@ -20,6 +21,7 @@ public class TypeUtil {
     /**
      * 将未知类型转换为目标类型
      */
+    @SneakyThrows
     public static Object typeStrConvertObject(Object obj, Class<?> targetType) {
         String str = obj.toString();
         if (NumberUtils.isCreatable(str)) {
@@ -39,6 +41,8 @@ public class TypeUtil {
             return Double.valueOf(str);
         } else if (boolean.class == targetType || Boolean.class == targetType) {
             return Boolean.valueOf(str);
+        } else if (targetType.isEnum()) {
+            return targetType.getMethod("valueOf", String.class).invoke(targetType, str);
         } else {
             return str;
         }


### PR DESCRIPTION
[新特性]  类型转换添加枚举类支持
效果简述
在entity中, 字段可以直接使用枚举类, 构建查询条件时可直接查询

大致样例
entity类
```
@Enumerated(EnumType.STRING) // 可不使用
private ChannelEnum channel;
```
要构造的VLModel
```
new VLModel(enum.toString(), "展示名称")
或
new VLModel(enum.name(), "展示名称") // 推荐方式
```