### PR TITLE
修复TPL模板支持动态传参时，访问403的bug

### DIFF
--- a/erupt-upms/src/main/java/xyz/erupt/upms/service/EruptUserService.java
+++ b/erupt-upms/src/main/java/xyz/erupt/upms/service/EruptUserService.java
@@ -71,7 +71,7 @@ public class EruptUserService {
         Map<String, Object> valueMap = new HashMap<>();
         for (EruptMenu menu : eruptMenus) {
             if (null != menu.getValue()) {
-                valueMap.put(menu.getValue().toLowerCase(), menu);
+                valueMap.put(menu.getValue().toLowerCase().split("\\?")[0], menu);
             }
         }
         sessionService.putMap(SessionKey.MENU_VALUE_MAP + token, valueMap, eruptUpmsProp.getExpireTimeByLogin());

--- a/erupt-upms/src/main/java/xyz/erupt/upms/service/EruptUserService.java
+++ b/erupt-upms/src/main/java/xyz/erupt/upms/service/EruptUserService.java
@@ -71,6 +71,7 @@ public class EruptUserService {
         Map<String, Object> valueMap = new HashMap<>();
         for (EruptMenu menu : eruptMenus) {
             if (null != menu.getValue()) {
+                // 当菜单是TPL时，类型值中有可能有参数（如：amis.html?code=test），这里需要把参数(?code=test)去除
                 valueMap.put(menu.getValue().toLowerCase().split("\\?")[0], menu);
             }
         }


### PR DESCRIPTION
#### 说明

比如用户配置的TPL菜单的类型值为：amis.html?code=test，用户的菜单缓存，key=amis.html?code=test，但是在TPL获取的authStr=amis.html，导致用户无权限

### 修改描述(包括说明bug修复或者添加新特性)

1. [bug修复] 用户登录时，将缓存的key仅保留?前的字符串