### PR TITLE
后缀判断，由于fileTypes配置没有加“点”无法拖动上传，拖动上传后代码没有判断到“点”导致上传类型错误

### DIFF
--- a/erupt-core/src/main/java/xyz/erupt/core/controller/EruptFileController.java
+++ b/erupt-core/src/main/java/xyz/erupt/core/controller/EruptFileController.java
@@ -77,7 +77,8 @@ public class EruptFileController {
                 if (attachmentType.fileTypes().length > 0) {
                     String[] fileNameArr = file.getOriginalFilename().split("\\.");
                     String extensionName = fileNameArr[fileNameArr.length - 1];
-                    if (Stream.of(attachmentType.fileTypes()).noneMatch(type -> extensionName.equalsIgnoreCase(type))) {
+                    String dotExtensionName = "." + extensionName;
+                    if (Stream.of(attachmentType.fileTypes()).noneMatch(type -> extensionName.equalsIgnoreCase(type) || dotExtensionName.equalsIgnoreCase(type))) {
                         return EruptApiModel.errorApi(I18nTranslate.$translate("erupt.upload_error.file_format") + ":" + extensionName);
                     }
                 }


### PR DESCRIPTION
### 修改描述(包括说明bug修复或者添加新特性)

1. [bug修复] 
如附件配置：`@AttachmentType(fileTypes={"zip"})`，拖拽文件无法上传。改成`@AttachmentType(fileTypes={".zip"})`后拖拽可以上传，但是后台校验失败没有判断到“点”