### PR TITLE
TAB_TABLE_REFER多对多表引用组件支持根据前端已录入的信息过滤弹窗数据

### DIFF
--- a/erupt-annotation/src/main/java/xyz/erupt/annotation/sub_field/Edit.java
+++ b/erupt-annotation/src/main/java/xyz/erupt/annotation/sub_field/Edit.java
@@ -95,8 +95,8 @@ public @interface Edit {
 
     @Match("#item.type().toString()=='REFERENCE_TREE'")
     ReferenceTreeType referenceTreeType() default @ReferenceTreeType;
-
-    @Match("#item.type().toString()=='REFERENCE_TABLE'")
+    
+	@Match("#item.type().toString()=='REFERENCE_TABLE' || #item.type().toString()=='TAB_TABLE_REFER'")
     ReferenceTableType referenceTableType() default @ReferenceTableType;
 
     @Transient


### PR DESCRIPTION
关联前端PR：[TAB_TABLE_REFER多对多表引用组件支持根据前端已录入的信息过滤弹窗数据](https://github.com/erupts/erupt-web/pull/79)

测试版本：2.1.18
1.问题说明：
目前组件TAB_TABLE_REFER多对多表引用组件不支持根据前端已录入的信息过滤可选择数据。

2.优化方案：
参考多对一表引用 REFERENCE_TABLE的联动效果实现，扩展ReferenceTableType注解支持的主键类型，支持TAB_TABLE_REFER组件。
![image](https://github.com/user-attachments/assets/dbe23b02-1d1f-4754-9e66-f0793080e3dd)
同时修改前端tab-table组件的addDataByRefer()方法，传递dependField字段指定的过滤值。
![image](https://github.com/user-attachments/assets/248a3569-43cb-425d-beb8-8843cc041bdc)

3.效果如下：
![image](https://github.com/user-attachments/assets/56f6c041-a16f-4a25-90a5-2aa16530c224)
![image](https://github.com/user-attachments/assets/1cb62542-217e-4a7a-86e9-c1fe187ff646)
![image](https://github.com/user-attachments/assets/38860b69-0a96-4ee9-b21a-e7ee7dc37d09)
![image](https://github.com/user-attachments/assets/67391bb1-b00e-4938-888f-6292fb28fe6b)


