### PR TITLE
修复Excel导入时ISO 8601规范的日期格式和数据库的TIMESTAMP格式导致异常

### DIFF
--- a/erupt-core/src/main/java/xyz/erupt/core/util/DateUtil.java
+++ b/erupt-core/src/main/java/xyz/erupt/core/util/DateUtil.java
@@ -1,8 +1,10 @@
 package xyz.erupt.core.util;
 
 import lombok.SneakyThrows;
+import org.apache.commons.lang3.time.DateUtils;
 import xyz.erupt.core.exception.EruptWebApiRuntimeException;
 
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -18,6 +20,24 @@ public class DateUtil {
     public static final String DATE = "yyyy-MM-dd";
 
     public static final String DATE_TIME = "yyyy-MM-dd HH:mm:ss";
+
+    private static final String[] PATTERNS = {
+            "yyyy-MM-dd'T'HH:mm:ss",//ISO 8601规范，用T分割
+            "yyyy-MM-dd' 'HH:mm:ss.SSS",//SQL/数据库的 TIMESTAMP
+            "yyyy-MM-dd' 'HH:mm:ss:SSS",//非规范
+            "yyyy-MM-dd HH:mm:ss",
+            "yyyy/MM/dd HH:mm:ss",
+            "dd-MM-yyyy",
+            "yyyy-MM-dd",
+            "dd/MM/yyyy"
+    };
+
+    /**
+     * 兼容多种格式的日期字符串，解析为Date对象
+     * */
+    public static Date parseDate(String dateStr) throws ParseException {
+        return DateUtils.parseDateStrictly(dateStr, PATTERNS);
+    }
 
     public static String getSimpleFormatDateTime(Date date) {
         return getFormatDate(date, DATE_TIME);

--- a/erupt-excel/src/main/java/xyz/erupt/excel/service/EruptExcelService.java
+++ b/erupt-excel/src/main/java/xyz/erupt/excel/service/EruptExcelService.java
@@ -228,7 +228,13 @@ public class EruptExcelService {
                             jsonObject.addProperty(eruptFieldModel.getFieldName(), bool);
                             break;
                         case DATE:
-                            jsonObject.addProperty(eruptFieldModel.getFieldName(), DateUtil.getSimpleFormatDateTime(cell.getDateCellValue()));
+                            Date dateCellValue;
+                            try {
+                                dateCellValue = cell.getDateCellValue();
+                            } catch (Exception e) {//如果允许引入fastjson，建议使用其中的TypeUtils.caseDate()方法,各种阴间的日期字符串都能解析
+                                dateCellValue = DateUtil.parseDate(cell.getStringCellValue());
+                            }
+                            jsonObject.addProperty(eruptFieldModel.getFieldName(), DateUtil.getSimpleFormatDateTime(dateCellValue));
                             break;
                         case NUMBER:
                             DataFormatter formatter = new DataFormatter();


### PR DESCRIPTION
#### 说明

1. 请确认你提交的PR是到 'develop' 分支，否则我会手动修改代码并关闭PR。
2. 请确认没有更改代码风格（如tab缩进）
3. 新特性添加请确认注释完备，如有必要，请在src/test/java下添加Junit测试用例

### 修改描述(包括说明bug修复或者添加新特性)

1. [bug修复] 修复Excel导入时ISO 8601规范的日期格式和数据库的TIMESTAMP格式导致异常
2. 
![wechat_2025-05-23_175303_060](https://github.com/user-attachments/assets/6e89b902-6df3-427c-80a7-f6c9033a7785)
![wechat_2025-05-23_175427_786](https://github.com/user-attachments/assets/d333a467-204d-4711-8fb4-bf167c2ab981)
