### PR TITLE
Add Requesty LLM provider

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -227,7 +227,7 @@ List<EruptUser> list = eruptDao.lambdaQuery(EruptUser.class)
 
 ### 支持 50+ 大模型提供商
 
-OpenAI · Claude · Gemini · DeepSeek · 通义千问 · 智谱 GLM · 豆包 · Moonshot · MiniMax · Mistral · Grok · Fireworks · Together · OpenRouter · Ollama（本地）—— **管理界面里随时热切换，共 50+ 个。**
+OpenAI · Claude · Gemini · DeepSeek · 通义千问 · 智谱 GLM · 豆包 · Moonshot · MiniMax · Mistral · Grok · Fireworks · Together · OpenRouter · Requesty · Ollama（本地）—— **管理界面里随时热切换，共 50+ 个。**
 
 ### 核心能力
 

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Full module catalog: **[erupt.xyz/#!/module](https://www.erupt.xyz/#!/module)** 
 
 ### Supported LLM providers
 
-OpenAI · Claude · Gemini · DeepSeek · Qwen · GLM · Doubao · Moonshot · MiniMax · Mistral · Grok · Fireworks · Together · OpenRouter · Ollama (self-hosted) — **hot-swappable from the admin UI, 50+ in total.**
+OpenAI · Claude · Gemini · DeepSeek · Qwen · GLM · Doubao · Moonshot · MiniMax · Mistral · Grok · Fireworks · Together · OpenRouter · Requesty · Ollama (self-hosted) — **hot-swappable from the admin UI, 50+ in total.**
 
 ### Key capabilities
 

--- a/erupt-ai/src/main/java/xyz/erupt/ai/llm/Requesty.java
+++ b/erupt-ai/src/main/java/xyz/erupt/ai/llm/Requesty.java
@@ -1,0 +1,18 @@
+package xyz.erupt.ai.llm;
+
+import org.springframework.stereotype.Component;
+import xyz.erupt.ai.core.OpenAI;
+
+@Component
+public class Requesty extends OpenAI {
+
+    @Override
+    public String model() {
+        return "openai/gpt-4o-mini";
+    }
+
+    @Override
+    public String api() {
+        return "https://router.requesty.ai";
+    }
+}


### PR DESCRIPTION
## Add Requesty LLM provider

This adds a native **Requesty** provider, mirroring the existing `OpenRouter` provider as closely as possible.

Requesty (https://requesty.ai) exposes an OpenAI-compatible router API and uses `provider/model` naming (e.g. `openai/gpt-4o-mini`), exactly like OpenRouter. It therefore slots in as a thin `OpenAI` subclass and self-registers through Spring's `@Component` scanning, the same mechanism every other provider in `erupt-ai/llm` uses via the `LlmCore` registry.

### Files changed
- `erupt-ai/src/main/java/xyz/erupt/ai/llm/Requesty.java` (new) — provider class extending `xyz.erupt.ai.core.OpenAI`, base URL `https://router.requesty.ai`, default chat path `/v1` (the `OpenAI` default), default model `openai/gpt-4o-mini`.
- `README.md` — added `Requesty` to the "Supported LLM providers" list.
- `README-zh.md` — added `Requesty` to the provider list (支持 50+ 大模型提供商).

### Registration sites touched
- The provider class itself (`@Component`). This is the only registration site: providers self-register in `LlmCore`'s static map keyed by `code()` (the class simple name), and are enumerated by `LlmCore.H` for the admin UI. There is no central enum, factory, or switch to update — same as `OpenRouter`, `Together`, `Fireworks`, etc.
- The two README provider lists.

### Compile status
I was not able to run a full module build in my environment — there was no Maven/JDK 17 toolchain available to resolve the langchain4j/Spring dependencies. The new class is a verbatim structural mirror of the existing, compiling `OpenRouter.java` (same imports, same `@Component`, same overridden methods), so it should build identically. Happy to confirm against CI.

### Live endpoint test
I verified the Requesty endpoints live before opening this PR:
- `GET https://router.requesty.ai/v1/models` → `200`
- `POST https://router.requesty.ai/v1/chat/completions` with `{"model":"openai/gpt-4o-mini", ...}` → `200`, returned a real completion.

The resulting base URL used by langchain4j's `OpenAiChatModel` is `https://router.requesty.ai/v1` (from `api()` + the default `chatApiPoint()` `/v1`), and the client appends `/chat/completions`, matching the verified endpoint. The API key is supplied per-LLM through the admin UI / `LlmRequest`, identical to every other provider.

---

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it is not a fit.
