### PR TITLE
fix: restore broken star history chart

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -312,11 +312,11 @@ Claw 与 AI Harness 共享同一套基于 Role 的 Tool 安全机制 —— 非�
 
 > `觉得 Erupt 帮到了你？请给个 Star。` 开源不易，对项目成长帮助很大。
 
-<a href="https://www.star-history.com/?repos=erupts%2Ferupt&type=date&legend=top-left" target="_blank">
+<a href="https://star-history.dera.page/#erupts/erupt&type=date&legend=top-left" target="_blank">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/image?repos=erupts/erupt&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/image?repos=erupts/erupt&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/image?repos=erupts/erupt&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=erupts/erupt&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=erupts/erupt&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=erupts/erupt&type=date&legend=top-left" />
  </picture>
 </a>
 

--- a/README.md
+++ b/README.md
@@ -312,11 +312,11 @@ Read the [contribution guidelines](./.github/CONTRIBUTING.md), then open an [iss
 
 > `IF ERUPT SAVES YOU TIME — STAR IT.` It really helps the project grow.
 
-<a href="https://www.star-history.com/?repos=erupts%2Ferupt&type=date&legend=top-left" target="_blank">
+<a href="https://star-history.dera.page/#erupts/erupt&type=date&legend=top-left" target="_blank">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/image?repos=erupts/erupt&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/image?repos=erupts/erupt&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/image?repos=erupts/erupt&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=erupts/erupt&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=erupts/erupt&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=erupts/erupt&type=date&legend=top-left" />
  </picture>
 </a>
 


### PR DESCRIPTION
The star history charts on the project README have been broken because the previous source can no longer fetch stargazer data under current GitHub API restrictions. This change points the charts (including the localised README-zh version) at a working provider so the project growth graph displays correctly again.

The fix is needed now because the existing image endpoint fails to render and leaves the README chart empty.